### PR TITLE
Dvernon/concurrency issues fix

### DIFF
--- a/api/src/main/java/edu/utexas/tacc/tapis/files/api/FilesApplication.java
+++ b/api/src/main/java/edu/utexas/tacc/tapis/files/api/FilesApplication.java
@@ -200,8 +200,8 @@ public class FilesApplication extends ResourceConfig
       SshSessionPoolPolicy poolPolicy = SshSessionPoolPolicy.defaultPolicy()
               .setMaxConnectionDuration(Duration.ofHours(6))
               .setMaxConnectionIdleTime(Duration.ofMinutes(8))
-              .setMaxConnectionsPerKey(3)
-              .setMaxSessionsPerConnection(8)
+              .setMaxConnectionsPerKey(RuntimeSettings.get().getSshPoolApiMaxConnectionsPerKey())
+              .setMaxSessionsPerConnection(RuntimeSettings.get().getSshPoolApiMaxSessionsPerConnection())
               .setCleanupInterval(Duration.ofSeconds(15))
               .setTraceDuringCleanupFrequency(RuntimeSettings.get().getSshPoolTraceOnCleanupInterval())
               .setSessionCreationStrategy(SshSessionPoolPolicy.SessionCreationStrategy.MINIMIZE_CONNECTIONS);

--- a/api/src/main/resources/logback.xml
+++ b/api/src/main/resources/logback.xml
@@ -63,8 +63,9 @@
 
     <!-- Control library logging. -->
     <logger name="com.zaxxer.hikari" level="ERROR"/>
+    <logger name="org.apache.sshd.client.impl.DefaultSftpClient" level="TRACE"/>
 
-    <logger name="edu.utexas.tacc.tapis.shared.ssh" level="INFO"/>
+    <logger name="edu.utexas.tacc.tapis.shared.ssh" level="WARN"/>
 
     <!-- ssh session pooling logging.  set to "TRACE" for debugging message (very verbose) -->
     <logger name="edu.utexas.tacc.tapis.shared.ssh" level="DEBUG" additivity="false">

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestConcurrentTransfers.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestConcurrentTransfers.java
@@ -4,41 +4,36 @@ import com.google.gson.JsonObject;
 import edu.utexas.tacc.tapis.files.integration.transfers.configs.TestFileTransfersConfig;
 import edu.utexas.tacc.tapis.files.integration.transfers.configs.TransfersConfig;
 import edu.utexas.tacc.tapis.files.lib.models.FileInfo;
-import org.apache.commons.lang3.StringUtils;
-import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 public class TestConcurrentTransfers extends BaseTransfersIntegrationTest<TestFileTransfersConfig> {
-    private static final String TEMP_DIR_PREFIX = "TestFileTransfers_";
     private static final String TEST_CONFIG = "TestConcurrentTransfersConfig.json";
-
-    private class TransferThread extends Thread {
-
-        TransfersConfig transfersConfig;
-        Path filename;
+    private ExecutorService threadPool = null;
+    class TransferInfo {
+        private final TransfersConfig transfersConfig;
+        private final Path filename;
         String transferId;
 
-        TransferThread(TransfersConfig transfersConfig, Path filename) {
+        public TransferInfo(TransfersConfig transfersConfig, Path filename) {
             this.filename = filename;
             this.transfersConfig = transfersConfig;
+            this.transferId = transferId;
+        }
+        public String getTransferId() {
+            return transferId;
         }
 
-        @Override
-        public void run() {
-            IntegrationTestUtils.TransferDefinition transferDefinition = new IntegrationTestUtils.TransferDefinition();
-            transferDefinition.setSourcePath(transfersConfig.getTapisSourcePath(filename));
-            transferDefinition.setDestinationPath(transfersConfig.getTapisDestinationPath(filename));
-            JsonObject tapisResult = IntegrationTestUtils.instance.transferFiles(getBaseFilesUrl(), getToken(), "integrationTestTransfer", transferDefinition);
-            transferId = getIdFromTransferResult(tapisResult);
-            log.info("Submitted transfer request.  sourceId: " +
-                    transfersConfig.getSourceSystem() + "  sourcePath: " + transfersConfig.getSourcePath() + " " +
-                    "destinationSystem" + transfersConfig.getDestinationSystem() + "  destinationPath: " + transfersConfig.getDestinationPath() +
-                    "  Id: " + transferId);
+        public void setTransferId(String transferId) {
+            this.transferId = transferId;
         }
 
         public TransfersConfig getTransfersConfig() {
@@ -48,9 +43,29 @@ public class TestConcurrentTransfers extends BaseTransfersIntegrationTest<TestFi
         public Path getFilename() {
             return filename;
         }
+    }
 
-        public String getTransferId() {
-            return transferId;
+    private class TransferCallable implements Callable<TransferInfo> {
+        TransferInfo transferInfo;
+        TransferCallable(TransfersConfig transfersConfig, Path filename) {
+            this.transferInfo = new TransferInfo(transfersConfig, filename);
+        }
+
+        @Override
+        public TransferInfo call() {
+            TransfersConfig transfersConfig = this.transferInfo.getTransfersConfig();
+            Path filename =  this.transferInfo.getFilename();
+            IntegrationTestUtils.TransferDefinition transferDefinition = new IntegrationTestUtils.TransferDefinition();
+            transferDefinition.setSourcePath(transfersConfig.getTapisSourcePath(filename));
+            transferDefinition.setDestinationPath(transfersConfig.getTapisDestinationPath(filename));
+            JsonObject tapisResult = IntegrationTestUtils.instance.transferFiles(getBaseFilesUrl(), getToken(), "integrationTestTransfer", transferDefinition);
+            String transferId = getIdFromTransferResult(tapisResult);
+            transferInfo.setTransferId(transferId);
+            log.info("Submitted transfer request.  sourceId: " +
+                    transfersConfig.getSourceSystem() + "  sourcePath: " + transfersConfig.getSourcePath() + " " +
+                    "destinationSystem" + transfersConfig.getDestinationSystem() + "  destinationPath: " + transfersConfig.getDestinationPath() +
+                    "  Id: " + transferId);
+            return transferInfo;
         }
     }
 
@@ -62,39 +77,63 @@ public class TestConcurrentTransfers extends BaseTransfersIntegrationTest<TestFi
         cleanup();
     }
 
+    @Override
+    public ExecutorService getThreadPool() {
+        if(threadPool == null) {
+            synchronized (this) {
+                if(threadPool == null) {
+                    threadPool = Executors.newFixedThreadPool(getTestConfig().getMaxThreads());
+                }
+            }
+        }
+        return threadPool;
+    }
+
     @Test
     public void testConcurrentTransfers() throws Exception {
         List<TransfersConfig> transfersConfigs = getTestConfig().getTransfers();
-        List<String> transferTasks = new ArrayList<>();
-        List<TransferThread> transferThreads = new ArrayList<>();
+        List<TransferInfo> transferInfos = new ArrayList<>();
+        List<Future<TransferInfo>> transferFutures = new ArrayList<>();
 
+
+        // request all of the transfers
         for(TransfersConfig transfersConfig : transfersConfigs) {
             List<FileInfo> filesToTransfer = IntegrationTestUtils.instance.getListing(getBaseFilesUrl(), getToken(), transfersConfig.getSourceSystem(), transfersConfig.getSourcePath());
             for(FileInfo fileInfo : filesToTransfer) {
-                TransferThread t = new TransferThread(transfersConfig, Path.of(fileInfo.getPath()).getFileName());
-                t.start();
-                transferThreads.add(t);
+                Future<TransferInfo> transferFuture = getThreadPool().submit(new TransferCallable(transfersConfig, Path.of(fileInfo.getPath()).getFileName()));
+                transferFutures.add(transferFuture);
             }
         }
 
-        for(Thread t : transferThreads) {
-            t.join();
+        List<String> transferIds = new ArrayList<>();
+        // make a list of all of the transferIds
+        for(Future<TransferInfo> transferFuture : transferFutures) {
+            TransferInfo transferInfo = transferFuture.get();
+            transferIds.add(transferInfo.getTransferId());
+            transferInfos.add(transferInfo);
         }
 
+        // wait for aall tranfer ids to complete
+        IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferIds, getTestConfig().getTimeout(), threadPool);
 
-        for(TransferThread transferThread : transferThreads) {
-            TransfersConfig transfersConfig = transferThread.getTransfersConfig();
-            String transferId = transferThread.getTransferId();
-            Assert.assertTrue(StringUtils.isNotBlank(transferId));
-            transferTasks.add(transferId);
-            IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferTasks, transfersConfig.getTimeout());
-            transferTasks.clear();
+        // request download and validation of each file
+        List<Future<Void>> downloadFutures = new ArrayList<>();
+        for(TransferInfo transferInfo : transferInfos) {
+            Future<Void> dowloadFuture = threadPool.submit(new Callable<Void>() {
+                public Void call() throws Exception {
+                    TransfersConfig transfersConfig = transferInfo.getTransfersConfig();
+                    Path fileName = transferInfo.getFilename();
+                    IntegrationTestUtils.instance.downloadAndVerify(getBaseFilesUrl(), getToken(),
+                            transfersConfig.getDestinationSystem(), Path.of(transfersConfig.getDestinationPath().toString(), fileName.toString()), getTestFiles().get(fileName));
+                    return null;
+                }
+            });
+            downloadFutures.add(dowloadFuture);
+        }
 
-            Path fileName = transferThread.getFilename();
-            // download each file from the destination, and verify that is identical to the source.
-            IntegrationTestUtils.instance.downloadAndVerify(getBaseFilesUrl(), getToken(),
-                    transfersConfig.getDestinationSystem(), Path.of(transfersConfig.getDestinationPath().toString(), fileName.toString()), getTestFiles().get(fileName));
-
+        // Wait for each to complete.  The get will throw and exception if the validation fails
+        for(Future<Void> downloadFuture : downloadFutures) {
+            downloadFuture.get();
         }
     }
 

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestFileTransfers.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestFileTransfers.java
@@ -31,7 +31,7 @@ public class TestFileTransfers extends BaseTransfersIntegrationTest<TestFileTran
             List<FileInfo> filesToTransfer = IntegrationTestUtils.instance.getListing(getBaseFilesUrl(), getToken(), transfersConfig.getSourceSystem(), transfersConfig.getSourcePath());
             List<String> transferTasks = null;
             transferTasks = doIndividualTransfer(transfersConfig, filesToTransfer);
-            IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferTasks, transfersConfig.getTimeout());
+            IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferTasks, getTestConfig().getTimeout());
             transferTasks.clear();
             for(FileInfo fileInfo : filesToTransfer) {
                 Path fileName = Path.of(fileInfo.getPath()).getFileName();

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestMultiPathFileTransfers.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/TestMultiPathFileTransfers.java
@@ -31,7 +31,7 @@ public class TestMultiPathFileTransfers extends BaseTransfersIntegrationTest<Tes
             List<FileInfo> filesToTransfer = IntegrationTestUtils.instance.getListing(getBaseFilesUrl(), getToken(), transfersConfig.getSourceSystem(), transfersConfig.getSourcePath());
             List<String> transferTasks = null;
             transferTasks = doBatchTransfer(transfersConfig, filesToTransfer);
-            IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferTasks, transfersConfig.getTimeout());
+            IntegrationTestUtils.instance.waitForTransfers(getBaseFilesUrl(), getToken(), transferTasks, getTestConfig().getTimeout());
             transferTasks.clear();
             for(FileInfo fileInfo : filesToTransfer) {
                 Path fileName = Path.of(fileInfo.getPath()).getFileName();

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/TestFileTransfersConfig.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/TestFileTransfersConfig.java
@@ -4,9 +4,19 @@ import java.util.List;
 
 public class TestFileTransfersConfig extends BaseTransfersIntegrationConfig {
 
+    int maxThreads;
+    private long timeout = 10000;
     List<TransfersConfig> transfers;
 
     public List<TransfersConfig> getTransfers() {
         return transfers;
+    }
+
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    public long getTimeout() {
+        return timeout;
     }
 }

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/TransfersConfig.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/TransfersConfig.java
@@ -12,7 +12,6 @@ public class TransfersConfig {
     private String destinationSystem;
     private Path destinationPath;
     // default to waiting 10 seconds
-    private long timeout = 10000;
 
     public String getSourceSystem() {
         return sourceSystem;
@@ -48,9 +47,5 @@ public class TransfersConfig {
         Assert.assertFalse(relativeFilePath.isAbsolute());
         Path fullPath = getDestinationPath().resolve(relativeFilePath);
         return getDestinationProtocol() + "://" + getDestinationSystem() + "/" + fullPath.toString();
-    }
-
-    public long getTimeout() {
-        return timeout;
     }
 }

--- a/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/UploadFilesConfig.java
+++ b/api/src/test/java/edu/utexas/tacc/tapis/files/integration/transfers/configs/UploadFilesConfig.java
@@ -1,14 +1,12 @@
 package edu.utexas.tacc.tapis.files.integration.transfers.configs;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 import java.nio.file.Path;
 
 public class UploadFilesConfig {
     private String uploadSystem;
     private Path uploadPath;
     private int count;
-    private long size;
+    private int size;
 
     public String getUploadSystem() {
         return uploadSystem;
@@ -22,7 +20,7 @@ public class UploadFilesConfig {
         return count;
     }
 
-    public long getSize() {
+    public int getSize() {
         return size;
     }
 }

--- a/api/src/test/resources/TestConcurrentTransfersConfig.json
+++ b/api/src/test/resources/TestConcurrentTransfersConfig.json
@@ -1,9 +1,11 @@
 {
+  "maxThreads": 100,
+  "timeout": 300000,
   "uploadFiles": [
     {
       "uploadSystem": "tapisv3-storage1-dvernon",
       "uploadPath": "/integrationTest/uploaded/concurrent",
-      "count": 100,
+      "count": 200,
       "size": 1024
     }
   ],
@@ -14,8 +16,7 @@
       "sourcePath": "/integrationTest/uploaded/concurrent",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage2-dvernon",
-      "destinationPath": "/integrationTest/received/concurrent",
-      "timeout": 2000000
+      "destinationPath": "/integrationTest/received/concurrent"
     }
   ],
   "cleanup": [

--- a/api/src/test/resources/TestFileTransfersConfig.json
+++ b/api/src/test/resources/TestFileTransfersConfig.json
@@ -1,4 +1,5 @@
 {
+  "timeout": 200000,
   "uploadFiles": [
     {
       "uploadSystem": "tapisv3-storage1-dvernon",
@@ -20,18 +21,15 @@
       "sourcePath": "/integrationTest/uploaded/individual",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage2-dvernon",
-      "destinationPath": "/integrationTest/received/individual",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/individual"
     },
     {
       "sourceProtocol": "tapis",
       "sourceSystem": "tapisv3-storage2-dvernon",
       "sourcePath": "/integrationTest/received/individual",
-      "timeout": 200000,
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage2-dvernon",
-      "destinationPath": "/integrationTest/received/individual",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/individual"
     },
     {
       "sourceProtocol": "tapis",
@@ -39,8 +37,7 @@
       "sourcePath": "/integrationTest/received/individual",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage4-dvernon",
-      "destinationPath": "/integrationTest/received/individual",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/individual"
     },
     {
       "sourceProtocol": "tapis",
@@ -48,8 +45,7 @@
       "sourcePath": "/integrationTest/received/individual",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage1-dvernon",
-      "destinationPath": "/integrationTest/received/individual",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/individual"
     }
   ],
   "cleanup": [

--- a/api/src/test/resources/TestMultiPathFileTransfersConfig.json
+++ b/api/src/test/resources/TestMultiPathFileTransfersConfig.json
@@ -1,4 +1,5 @@
 {
+  "timeout": 200000,
   "uploadFiles": [
     {
       "uploadSystem": "tapisv3-storage1-dvernon",
@@ -20,8 +21,7 @@
       "sourcePath": "/integrationTest/uploaded/batch",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage2-dvernon",
-      "destinationPath": "/integrationTest/received/batch",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/batch"
     },
     {
       "sourceProtocol": "tapis",
@@ -29,8 +29,7 @@
       "sourcePath": "/integrationTest/received/batch",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage4-dvernon",
-      "destinationPath": "/integrationTest/received/batch",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/batch"
     },
     {
       "sourceProtocol": "tapis",
@@ -38,8 +37,7 @@
       "sourcePath": "/integrationTest/received/batch",
       "destinationProtocol": "tapis",
       "destinationSystem": "tapisv3-storage1-dvernon",
-      "destinationPath": "/integrationTest/received/batch",
-      "timeout": 200000
+      "destinationPath": "/integrationTest/received/batch"
     }
   ],
   "cleanup": [

--- a/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/config/IRuntimeConfig.java
+++ b/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/config/IRuntimeConfig.java
@@ -23,6 +23,10 @@ public interface IRuntimeConfig {
     int getDbConnectionPoolCoreSize();
     int getDbConnectionPoolSize();
     int getSshPoolTraceOnCleanupInterval();
+    int getSshPoolApiMaxConnectionsPerKey();
+    int getSshPoolApiMaxSessionsPerConnection();
+    int getSshPoolWorkerMaxConnectionsPerKey();
+    int getSshPoolWorkerMaxSessionsPerConnection();
     int getMaxTransferCount();
     public int getGrizzlyPoolCoreSize();
     public int getGrizzlyPoolMaxSize();

--- a/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/config/RuntimeSettings.java
+++ b/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/config/RuntimeSettings.java
@@ -31,6 +31,10 @@ public class RuntimeSettings {
         protected final int dbConnectionPoolCoreSize = getIntSetting("TAPIS_DB_CONNECTION_POOL_CORE_SIZE", 15);
         protected final int dbConnectionPoolSize = getIntSetting("TAPIS_DB_CONNECTION_POOL_SIZE", 20);
         protected final int sshPoolTraceOnCleanupInterval = getIntSetting("TAPIS_SSH_POOL_TRACE_ON_CLEANUP_INTERVAL", 4);
+        protected final int sshPoolApiMaxConnectionsPerKey = getIntSetting("TAPIS_SSH_POOL_API_MAX_CONNECTIONS_PER_KEY", 8);
+        protected final int sshPoolApiMaxSessionsPerConnection = getIntSetting("TAPIS_SSH_POOL_API_MAX_SESSIONS_PER_CONNECTION", 10);
+        protected final int sshPoolWorkerMaxConnectionsPerKey = getIntSetting("TAPIS_SSH_POOL_WORKER_MAX_CONNECTIONS_PER_KEY", 8);
+        protected final int sshPoolWorkerMaxSessionsPerConnection = getIntSetting("TAPIS_SSH_POOL_WORKER_MAX_SESSIONS_PER_CONNECTION", 10);
         protected final int grizzlyPoolCoreSize = getIntSetting("TAPIS_DB_CONNECTION_POOL_CORE_SIZE", 40);
         protected final int grizzlyPoolMaxSize = getIntSetting("TAPIS_DB_CONNECTION_POOL_SIZE", 50);
         protected final String tapisDebugSystemServicePath = settings.get("TAPIS_DEBUG_SYSTEM_SERVICE_PATH", null);
@@ -122,6 +126,22 @@ public class RuntimeSettings {
 
         public int getSshPoolTraceOnCleanupInterval() {
             return sshPoolTraceOnCleanupInterval;
+        }
+
+        public int getSshPoolApiMaxConnectionsPerKey() {
+            return sshPoolApiMaxConnectionsPerKey;
+        }
+
+        public int getSshPoolApiMaxSessionsPerConnection() {
+            return sshPoolApiMaxSessionsPerConnection;
+        }
+
+        public int getSshPoolWorkerMaxConnectionsPerKey() {
+            return sshPoolWorkerMaxConnectionsPerKey;
+        }
+
+        public int getSshPoolWorkerMaxSessionsPerConnection() {
+            return sshPoolWorkerMaxSessionsPerConnection;
         }
 
         public int getMaxTransferCount() {

--- a/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/transfers/TransfersApp.java
+++ b/lib/src/main/java/edu/utexas/tacc/tapis/files/lib/transfers/TransfersApp.java
@@ -107,8 +107,8 @@ public class TransfersApp
       SshSessionPoolPolicy poolPolicy = SshSessionPoolPolicy.defaultPolicy()
               .setMaxConnectionDuration(Duration.ofHours(6))
               .setMaxConnectionIdleTime(Duration.ofMinutes(8))
-              .setMaxConnectionsPerKey(5)
-              .setMaxSessionsPerConnection(8)
+              .setMaxConnectionsPerKey(RuntimeSettings.get().getSshPoolWorkerMaxConnectionsPerKey())
+              .setMaxSessionsPerConnection(RuntimeSettings.get().getSshPoolWorkerMaxSessionsPerConnection())
               .setCleanupInterval(Duration.ofSeconds(15))
               .setTraceDuringCleanupFrequency(RuntimeSettings.get().getSshPoolTraceOnCleanupInterval())
               .setSessionCreationStrategy(SshSessionPoolPolicy.SessionCreationStrategy.MINIMIZE_CONNECTIONS);

--- a/lib/src/main/resources/logback.xml
+++ b/lib/src/main/resources/logback.xml
@@ -70,7 +70,7 @@
     <logger name="com.zaxxer.hikari" level="ERROR"/>
 
     <!-- by default, don't log ssh pool trace info to stdout or normal log files.  set to trace to enable -->
-    <logger name="edu.utexas.tacc.tapis.shared.ssh" level="INFO"/>
+    <logger name="edu.utexas.tacc.tapis.shared.ssh" level="WARN"/>
 
     <!-- ssh session pooling logging.  logs to a separate file -->
     <logger name="edu.utexas.tacc.tapis.shared.ssh" level="DEBUG" additivity="false">

--- a/lib/src/test/java/edu/utexas/tacc/tapis/files/test/RandomByteInputStream.java
+++ b/lib/src/test/java/edu/utexas/tacc/tapis/files/test/RandomByteInputStream.java
@@ -2,6 +2,8 @@ package edu.utexas.tacc.tapis.files.test;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,8 +12,7 @@ import java.io.PipedOutputStream;
 import java.security.NoSuchAlgorithmException;
 
 public class RandomByteInputStream extends InputStream {
-//    private final MessageDigest digest;
-
+    private static Logger log = LoggerFactory.getLogger(RandomByteInputStream.class);
     private int bytesRead = 0;
     private final int bytesAvailable;
     private final int maxChunkSize;


### PR DESCRIPTION
This change contains a bunch of enhancements to the tests and test framework.  The biggest part of it is allowing multithreaded upload of files and validation of transfers.  I wont go into details about the test changes though.

As for the real changes:
I moved the max connections/sessions out to external configuration for both the api and the worker (they are independent settings).  In retrospect maybe I could have called them the same thing - we can talk about it during the review.

Changed logback settings for the sshpool logs to go with the changes in the shared library.

Made changes in the SSHDataClient to prevent deadlocks.
